### PR TITLE
deploy: reflect new API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,13 @@ jobs:
           kubectl wait --for=condition=Ready pod/object-storage-consumer
       - name: Test
         run: |
-          kubectl cp object-storage-consumer:/data/cosi/credentials.json credentials.json
+          kubectl cp object-storage-consumer:/data/cosi/credentials credentials
           kubectl cp object-storage-consumer:/data/cosi/protocolConn.json protocolConn.json
 
-          test "$(jq '.endpoint' protocolConn.json)" = '"object-storage.local"'
+          # See https://kubernetes.slack.com/archives/C017EGC1C6N/p1620683108305500
+          #test "$(jq '.endpoint' protocolConn.json)" = '"object-storage.local"'
           test "$(jq '.region' protocolConn.json)" = '"test"'
           test "$(jq '.signatureVersion' protocolConn.json)" = '"S3V4"'
 
-          test "$(jq '.CredentialsFileContents' credentials.json)" = '"# Nothing to see here"'
-          test "$(jq '.CredentialsFilePath' credentials.json)" = '".aws/credentials"'
+          test "$(jq '.CredentialsFileContents' credentials)" = '"# Nothing to see here"'
+          test "$(jq '.CredentialsFilePath' credentials)" = '".aws/credentials"'

--- a/deploy/base/bucketclass.yml
+++ b/deploy/base/bucketclass.yml
@@ -12,8 +12,6 @@ allowedNamespaces:
   - default
 protocol:
   s3:
-    bucketName: unused
-    endpoint: object-storage.local
     region: test
     signatureVersion: S3V4
 deletionPolicy: Delete


### PR DESCRIPTION
Recent changes in the API removed the `endpoint` and `bucketName` fields
from the `S3Protocol` structure (in the CRD). This change reflects the
API change so CI succeeds again.

See: https://github.com/kubernetes-sigs/container-object-storage-interface-api/pull/41