### PR TITLE
*: update version of `cosi-spec`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,5 +142,7 @@ jobs:
           test "$(jq '.region' protocolConn.json)" = '"test"'
           test "$(jq '.signatureVersion' protocolConn.json)" = '"S3V4"'
 
+          # This may be unintentional, a bug in the CSI driver.
+          # See https://kubernetes.slack.com/archives/C017EGC1C6N/p1620729488311200
           test "$(jq '.CredentialsFileContents' credentials)" = '"# Nothing to see here"'
-          test "$(jq '.CredentialsFilePath' credentials)" = '".aws/credentials"'
+          test "$(jq '.CredentialsFilePath' credentials)" = '""'

--- a/cmd/cosi-driver-sample/provisionerserver.go
+++ b/cmd/cosi-driver-sample/provisionerserver.go
@@ -181,9 +181,8 @@ func (s *provisionerServer) ProvisionerGrantBucketAccess(ctx context.Context, re
 	}
 
 	return &spec.ProvisionerGrantBucketAccessResponse{
-		AccountId:               a.accountId.String(),
-		CredentialsFileContents: "# Nothing to see here",
-		CredentialsFilePath:     ".aws/credentials",
+		AccountId:   a.accountId.String(),
+		Credentials: "# Nothing to see here",
 	}, nil
 }
 

--- a/cmd/cosi-driver-sample/provisionerserver_test.go
+++ b/cmd/cosi-driver-sample/provisionerserver_test.go
@@ -45,8 +45,6 @@ var _ = Describe("ProvisionerServer", func() {
 			Protocol: &spec.Protocol{
 				Type: &spec.Protocol_S3{
 					S3: &spec.S3{
-						Endpoint:         "https://object-storage.internal",
-						BucketName:       bucketName,
 						Region:           "test",
 						SignatureVersion: spec.S3SignatureVersion_S3V4,
 					},
@@ -94,7 +92,6 @@ var _ = Describe("ProvisionerServer", func() {
 				Protocol: &spec.Protocol{
 					Type: &spec.Protocol_AzureBlob{
 						AzureBlob: &spec.AzureBlob{
-							ContainerName:  "test-azure-blob-container",
 							StorageAccount: "test-sa",
 						},
 					},
@@ -174,8 +171,7 @@ var _ = Describe("ProvisionerServer", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(aresp2.AccountId).To(Equal(aresp1.AccountId))
-			Expect(aresp2.CredentialsFileContents).To(Equal(aresp1.CredentialsFileContents))
-			Expect(aresp2.CredentialsFilePath).To(Equal(aresp1.CredentialsFilePath))
+			Expect(aresp2.Credentials).To(Equal(aresp1.Credentials))
 		})
 
 		It("Handles requests for access to non-existing buckets", func() {

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,5 @@ require (
 	golang.org/x/sys v0.0.0-20210503173754-0981d6026fa6
 	google.golang.org/grpc v1.37.0
 	k8s.io/klog/v2 v2.8.0
-	sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210330184956-b0de747ccee4
+	sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210507203703-a97f2e98ac90
 )

--- a/go.sum
+++ b/go.sum
@@ -154,5 +154,5 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 k8s.io/klog/v2 v2.8.0 h1:Q3gmuM9hKEjefWFFYF0Mat+YyFJvsUyYuwyNNJ5C9Ts=
 k8s.io/klog/v2 v2.8.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
-sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210330184956-b0de747ccee4 h1:U+M87V77xKotSub2dqNlmxHMbb30QeC7wwTWdPGAhSI=
-sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210330184956-b0de747ccee4/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210507203703-a97f2e98ac90 h1:gC+gbzEMq1EPR+QmXuDmC50USLWLY/8Ci2ezgqhloUs=
+sigs.k8s.io/container-object-storage-interface-spec v0.0.0-20210507203703-a97f2e98ac90/go.mod h1:kafkL5l/lTUrZXhVi/9p1GzpEE/ts29BkWkL3Ao33WU=


### PR DESCRIPTION
This bumps the version of the spec to that of May 4th, 2021, including
the changes introduced in 392ee587932b2c764d9600854b049897f0979b4e.

See: https://github.com/kubernetes-sigs/container-object-storage-interface-spec/commit/392ee587932b2c764d9600854b049897f0979b4e
See: https://github.com/kubernetes-sigs/container-object-storage-interface-spec/pull/27