### PR TITLE
cmd: move `ProvisionerServer` implementation into `internal/`

### DIFF
--- a/cmd/cosi-driver-sample/main.go
+++ b/cmd/cosi-driver-sample/main.go
@@ -18,6 +18,7 @@ import (
 
 	"k8s.io/klog/v2"
 
+	"github.com/scality/cosi-driver-sample/internal/provisionerserver"
 	"github.com/scality/cosi-driver-sample/pkg/cosidriver"
 )
 
@@ -33,7 +34,7 @@ func main() {
 
 	defer klog.Flush()
 
-	provisionerServer := NewProvisionerServer()
+	provisionerServer := provisionerserver.NewProvisionerServer()
 
 	err := cosidriver.Run(*endpoint, driverName, provisionerServer)
 	if err != nil {

--- a/internal/provisionerserver/provisionerserver.go
+++ b/internal/provisionerserver/provisionerserver.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package provisionerserver
 
 import (
 	"context"

--- a/internal/provisionerserver/provisionerserver_suite_test.go
+++ b/internal/provisionerserver/provisionerserver_suite_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main_test
+package provisionerserver_test
 
 import (
 	. "github.com/onsi/ginkgo"
@@ -21,5 +21,5 @@ import (
 
 func TestMain(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "cosi-driver-sample")
+	RunSpecs(t, "provisionerserver")
 }

--- a/internal/provisionerserver/provisionerserver_test.go
+++ b/internal/provisionerserver/provisionerserver_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main_test
+package provisionerserver_test
 
 import (
 	"context"
@@ -25,7 +25,7 @@ import (
 
 	spec "sigs.k8s.io/container-object-storage-interface-spec"
 
-	main "github.com/scality/cosi-driver-sample/cmd/cosi-driver-sample"
+	"github.com/scality/cosi-driver-sample/internal/provisionerserver"
 )
 
 var _ = Describe("ProvisionerServer", func() {
@@ -36,7 +36,7 @@ var _ = Describe("ProvisionerServer", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		provisionerServer = main.NewProvisionerServer()
+		provisionerServer = provisionerserver.NewProvisionerServer()
 	})
 
 	mkCreateBucketRequest := func(bucketName string) *spec.ProvisionerCreateBucketRequest {


### PR DESCRIPTION
This code is not really part of the application entry-point, hence moving it into its own package.